### PR TITLE
test(persistence): improve test coverage for issue #20

### DIFF
--- a/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/JsonPersisterTest.java
+++ b/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/JsonPersisterTest.java
@@ -294,4 +294,75 @@ public class JsonPersisterTest
         assertEquals("sha-1", digestResult.digest().getAlgorithm());
         assertEquals("0000111122223333444455556666777788889999aaaa", digestResult.digest().toHex());
     }
+
+    @Test
+    public void testPrettyPrintProducesIndentedOutput() throws PersistenceException {
+        DirHasherResult obj = new DirHasherResult();
+        DigestResult dr = new DigestResult();
+        dr.add(new Digest("sha-1", "0000111122223333444455556666777788889999aaaa"));
+        obj.put("file.txt", dr);
+
+        ByteArrayOutputStream prettyOut = new ByteArrayOutputStream();
+        new JsonPersistenceProvider(true).persist(prettyOut, obj);
+
+        // Reset OBJECT_MAPPER to compact for other tests
+        ByteArrayOutputStream compactOut = new ByteArrayOutputStream();
+        new JsonPersistenceProvider(false).persist(compactOut, obj);
+
+        assertTrue("Pretty-printed JSON must contain newlines", prettyOut.toString().contains("\n"));
+        assertTrue("Pretty-printed output should be longer than compact output",
+            prettyOut.toString().length() > compactOut.toString().length());
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testPersistIOExceptionIsWrapped() throws PersistenceException {
+        OutputStream failingStream = new OutputStream() {
+            @Override
+            public void write(final int b) throws IOException {
+                throw new IOException("Simulated failure");
+            }
+
+            @Override
+            public void write(final byte[] b, final int off, final int len) throws IOException {
+                throw new IOException("Simulated failure");
+            }
+        };
+        new JsonPersistenceProvider().persist(failingStream, new DigestResult());
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testLoadMalformedJsonThrows() throws PersistenceException {
+        new JsonPersistenceProvider().load(new StringReader("{not valid json]"), DigestResult.class);
+    }
+
+    @Test
+    public void testRoundTripMultipleFilesAndDigests() throws PersistenceException {
+        DirHasherResult obj = new DirHasherResult();
+
+        DigestResult dr1 = new DigestResult();
+        dr1.add(new Digest("md5", "a4850cd827a34a7e54dacf6814e06f55"));
+        dr1.add(new Digest("sha-1", "23e7ace892b507b07e4dfcf1f028ee3130bc682e"));
+        obj.put("file1.txt", dr1);
+
+        DigestResult dr2 = new DigestResult();
+        dr2.add(new Digest("md5", "44af6da725a24c2d8363a42069ee110f"));
+        obj.put("file2.txt", dr2);
+
+        JsonPersistenceProvider provider = new JsonPersistenceProvider();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        provider.persist(out, obj);
+
+        DirHasherResult loaded = provider.load(new StringReader(out.toString()), DirHasherResult.class);
+        assertEquals(2, loaded.size());
+        assertEquals(obj, loaded);
+    }
+
+    @Test
+    public void testLoadDirHasherResultWithTypeReference() throws PersistenceException {
+        TypeReference<DirHasherResult> typeRef = new TypeReference<DirHasherResult>() { };
+        JsonPersistenceProvider provider = new JsonPersistenceProvider();
+        DirHasherResult result = provider.load(new StringReader(this.testDirHasherResultInJson), typeRef);
+        assertEquals(1, result.size());
+        assertTrue("Should contain myfile", result.containsKey("myfile"));
+    }
 }

--- a/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/OldStylePersistenceProviderTest.java
+++ b/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/OldStylePersistenceProviderTest.java
@@ -28,14 +28,16 @@
 
 package nl.minjus.nfi.dt.jhashtools.persistence;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import nl.minjus.nfi.dt.jhashtools.Digest;
+import nl.minjus.nfi.dt.jhashtools.DigestResult;
 import nl.minjus.nfi.dt.jhashtools.DirHasherResult;
 import nl.minjus.nfi.dt.jhashtools.exceptions.PersistenceException;
 import org.junit.Test;
 
 import java.io.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class OldStylePersistenceProviderTest
 {
@@ -64,5 +66,95 @@ public class OldStylePersistenceProviderTest
         } catch (PersistenceException e) {
             fail(e.toString());
         }
+    }
+
+    @Test
+    public void testPersistDirHasherResult() throws PersistenceException {
+        DigestResult digestResult = new DigestResult();
+        digestResult.add(new Digest("md5", "a4850cd827a34a7e54dacf6814e06f55"));
+        DirHasherResult obj = new DirHasherResult();
+        obj.put("somefile.txt", digestResult);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        OldStylePersistenceProvider provider = new OldStylePersistenceProvider();
+        provider.persist(out, obj);
+
+        String output = out.toString();
+        assertTrue("Output must start with header", output.startsWith("Generated with: "));
+        assertTrue("Output must contain file name", output.contains("somefile.txt"));
+        assertTrue("Output must contain digest algorithm", output.contains("md5"));
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testPersistNullThrows() throws PersistenceException {
+        new OldStylePersistenceProvider().persist(new ByteArrayOutputStream(), null);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testPersistNonDirHasherResultThrows() throws PersistenceException {
+        new OldStylePersistenceProvider().persist(new ByteArrayOutputStream(), "not a DirHasherResult");
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testLoadWithTypeReferenceThrows() throws PersistenceException {
+        TypeReference<DirHasherResult> typeRef = new TypeReference<DirHasherResult>() { };
+        new OldStylePersistenceProvider().load(new StringReader(""), typeRef);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testLoadWrongClassThrows() throws PersistenceException {
+        new OldStylePersistenceProvider().load(
+            new StringReader("Generated with: something\n"),
+            String.class);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testLoadBadHeaderThrows() throws PersistenceException {
+        new OldStylePersistenceProvider().load(
+            new StringReader("WRONG HEADER\nsomefile.txt\n"),
+            DirHasherResult.class);
+    }
+
+    @Test
+    public void testLoadHeaderOnlyReturnsEmptyResult() throws PersistenceException {
+        DirHasherResult result = new OldStylePersistenceProvider().load(
+            new StringReader("Generated with: jHashtools\n"),
+            DirHasherResult.class);
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testLoadSingleFileWithDigests() throws PersistenceException {
+        // The parser grammar requires uppercase MD5: / SHA-1: / SHA-256: tokens.
+        String input = "Generated with: jHashtools 1.0\n"
+            + "somefile.txt\n"
+            + "\tMD5:\ta4850cd827a34a7e54dacf6814e06f55\n"
+            + "\tSHA-1:\t23e7ace892b507b07e4dfcf1f028ee3130bc682e\n";
+
+        DirHasherResult result = new OldStylePersistenceProvider().load(
+            new StringReader(input), DirHasherResult.class);
+
+        assertEquals(1, result.size());
+        assertTrue("Result must contain somefile.txt", result.containsKey("somefile.txt"));
+        DigestResult dr = result.get("somefile.txt");
+        assertEquals("md5:a4850cd827a34a7e54dacf6814e06f55", dr.getDigest("md5").toString());
+        assertEquals("sha-1:23e7ace892b507b07e4dfcf1f028ee3130bc682e", dr.getDigest("sha-1").toString());
+    }
+
+    @Test
+    public void testLoadMultipleFiles() throws PersistenceException {
+        String input = "Generated with: jHashtools 1.0\n"
+            + "file1.txt\n"
+            + "\tMD5:\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            + "file2.txt\n"
+            + "\tSHA-1:\tbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
+
+        DirHasherResult result = new OldStylePersistenceProvider().load(
+            new StringReader(input), DirHasherResult.class);
+
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("file1.txt"));
+        assertTrue(result.containsKey("file2.txt"));
     }
 }

--- a/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/PersistenceStyleTest.java
+++ b/src/test/java/nl/minjus/nfi/dt/jhashtools/persistence/PersistenceStyleTest.java
@@ -24,4 +24,9 @@ public class PersistenceStyleTest {
         PersistenceStyle expected = PersistenceStyle.convert("old");
         assertThat(expected, is(equalTo(PersistenceStyle.OLDSTYLE)));
     }
+
+    @Test(expected = RuntimeException.class)
+    public void testConvertUnknownStringThrows() {
+        PersistenceStyle.convert("unknown");
+    }
 }


### PR DESCRIPTION
## Motivation

The persistence package had ~44% method coverage and ~70% line coverage (issue #20). Many important code paths -- error handling in `OldStylePersistenceProvider.persist`, unsupported operation branches, and the `TypeReference`-based load path in `JsonPersistenceProvider` -- had zero test coverage.

## What changed

Added 15 new tests across three test classes to cover the gaps:

**`OldStylePersistenceProviderTest`** (persist was entirely untested before):
- `persist` happy path -- verifies header line, file name, and algorithm appear in output
- `persist(null)` and `persist(non-DirHasherResult)` both throw `PersistenceException`
- `load(Reader, TypeReference)` always throws `PersistenceException` (unsupported path)
- `load` with wrong target class throws `PersistenceException`
- `load` with a missing/bad header line throws `PersistenceException`
- `load` with header-only input returns an empty `DirHasherResult`
- `load` parses a single file with MD5 + SHA-1 digests correctly
- `load` parses multiple files correctly

**`JsonPersisterTest`**:
- `JsonPersistenceProvider(true)` produces indented, multi-line output
- `persist` wraps an `IOException` in a `PersistenceException`
- `load` with malformed JSON throws `PersistenceException`
- Round-trip with multiple files and multiple digests per file
- `load(Reader, TypeReference<DirHasherResult>)` exercises the TypeReference code path

**`PersistenceStyleTest`**:
- `convert("unknown")` throws `RuntimeException`

Total tests: 187 (up from 172), all passing.

Closes #20